### PR TITLE
Chat Excryption

### DIFF
--- a/src/main/java/canttouchthis/common/CryptoServices.java
+++ b/src/main/java/canttouchthis/common/CryptoServices.java
@@ -34,7 +34,7 @@ public class CryptoServices {
      * @throws Exception For all possible exceptions (i.e. invalid key, bad padding, etc.)
      */
     public Cipher getEncryptCipher(Key key) throws Exception {
-        Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        Cipher c = Cipher.getInstance("AES/CTR/PKCS5Padding");
         c.init(Cipher.ENCRYPT_MODE, key, ivspec);
 
         return c;
@@ -48,7 +48,7 @@ public class CryptoServices {
      * @throws Exception For all possible exceptions (i.e. invalid key, bad padding, etc.)
      */
     public Cipher getDecryptCipher(Key key) throws Exception {
-        Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        Cipher c = Cipher.getInstance("AES/CTR/PKCS5Padding");
         c.init(Cipher.DECRYPT_MODE, key, ivspec);
 
         return c;
@@ -63,7 +63,7 @@ public class CryptoServices {
      * @throws Exception For all possible exceptions (i.e. invalid key, bad padding, etc.)
      */
     public byte[] encryptSymmetric(byte[] plaintext, Key key) throws Exception {
-        Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        Cipher c = Cipher.getInstance("AES/CTR/PKCS5Padding");
         c.init(Cipher.ENCRYPT_MODE, key, ivspec);
         byte[] ciphertext = new byte[c.getOutputSize(plaintext.length)];
         c.doFinal(plaintext, 0, plaintext.length, ciphertext);
@@ -79,7 +79,7 @@ public class CryptoServices {
      * @throws Exception For all possible exceptions (i.e. invalid key, bad padding, etc.)
      */
     public String decryptSymmetric(byte[] ciphertext, Key key) throws Exception {
-        Cipher c = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        Cipher c = Cipher.getInstance("AES/CTR/PKCS5Padding");
         c.init(Cipher.DECRYPT_MODE, key, ivspec);
         byte[] newPlaintext = new byte[c.getOutputSize(ciphertext.length)];
         c.doFinal(ciphertext, 0, newPlaintext.length, newPlaintext);

--- a/src/main/java/canttouchthis/common/IChatSession.java
+++ b/src/main/java/canttouchthis/common/IChatSession.java
@@ -10,7 +10,7 @@ public interface IChatSession {
      * @return New Message object from server.
      * @throws IOException If an error is encountered reading from the websocket stream.
      */
-    public Message getNextMessage() throws IOException;
+    public Message getNextMessage() throws Exception;
 
     /**
      * Sends a Message object to the server.
@@ -18,6 +18,6 @@ public interface IChatSession {
      * @param m Message to be sent.
      * @throws IOException If an error is encountered sending over the websocket.
      */
-    public void sendMessage(Message m) throws IOException;
+    public void sendMessage(Message m) throws Exception;
 
 }

--- a/src/main/java/canttouchthis/common/MessageMonitorThread.java
+++ b/src/main/java/canttouchthis/common/MessageMonitorThread.java
@@ -39,7 +39,7 @@ public class MessageMonitorThread extends Thread {
                     ui.addMessage(m);
                     session.sendMessage(m);
                 }
-                catch (IOException ex) {
+                catch (Exception ex) {
                     ex.printStackTrace(System.err);
                 }
             }
@@ -68,6 +68,10 @@ public class MessageMonitorThread extends Thread {
             catch (IOException ex) {
                 ex.printStackTrace(System.err);
                 this._ui.showFatal("Error in websocket transmission!");
+            }
+            catch (Exception ex) {
+                ex.printStackTrace(System.err);
+                this._ui.showFatal("An error occurred: " + ex.getMessage());
             }
         }
     }

--- a/src/test/java/ctttest/common/TestCryptoServices.java
+++ b/src/test/java/ctttest/common/TestCryptoServices.java
@@ -1,7 +1,10 @@
 package ctttest.common;
 
+import canttouchthis.common.Message;
 import canttouchthis.common.CryptoServices;
 
+import java.io.ObjectOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.security.*;
 import javax.crypto.*;
 
@@ -27,4 +30,47 @@ public class TestCryptoServices extends TestCase {
 
         assertEquals(message, newPlainText);
     }
+
+    /**
+     * Checks that a CipherOutputStream using our CryptoUtils ciphers actually encrypts an
+     * object from an ObjectOutputStream.
+     *
+     * To verify this manually, run at the end of the string:
+     *      System.out.println(unencryptedString);
+     *      System.out.println(encryptedString);
+     *
+     * @throws Exception If any issues are encountered initializing the cipher.
+     */
+    public void testCipherStreamsActuallyEncrypt() throws Exception {
+
+        // Generate random key for symmetric crypto
+        KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+        keyGen.init(128);
+        Key key = keyGen.generateKey();
+
+        // Create generic message
+        Message m = new Message("I am a walrus.", 12);
+
+        // Create two pipelines: one uses the encryption cipher, one doesn't
+        ByteArrayOutputStream byteStreamNoEncrypt = new ByteArrayOutputStream();
+        ObjectOutputStream oosNoEncrypt = new ObjectOutputStream(byteStreamNoEncrypt);
+
+        Cipher c = (new CryptoServices()).getEncryptCipher(key);
+        ByteArrayOutputStream byteStreamEncrypted = new ByteArrayOutputStream();
+        CipherOutputStream cos = new CipherOutputStream(byteStreamEncrypted, c);
+        ObjectOutputStream oosEncrypted = new ObjectOutputStream(cos);
+
+        // EXEC: Write the message to the encrypted and unencrypted pipeline
+        oosEncrypted.writeObject(m);
+        oosNoEncrypt.writeObject(m);
+
+        // Get byte strings from the end of the pipe
+        String unencryptedString = new String(byteStreamNoEncrypt.toByteArray());
+        String encryptedString = new String(byteStreamEncrypted.toByteArray());
+
+        assertFalse("Encrypted and unencrypted streams should not be the same.",
+                unencryptedString.equals(encryptedString));
+
+    }
+
 }

--- a/src/test/java/ctttest/net/TestClientServerConnection.java
+++ b/src/test/java/ctttest/net/TestClientServerConnection.java
@@ -36,7 +36,7 @@ public class TestClientServerConnection extends TestCase {
             cThread.join();
             s.close();
         }
-        catch (IOException|InterruptedException ex) {
+        catch (Exception ex) {
             assertTrue("Exception when sending message!", false);
         }
 
@@ -68,7 +68,7 @@ public class TestClientServerConnection extends TestCase {
             c.sendMessage(m);
             sThread.join();
         }
-        catch (IOException|InterruptedException ex) {
+        catch (Exception ex) {
             assertTrue("Exception when sending message!", false);
         }
 


### PR DESCRIPTION
So I think I may have figured out how to encrypt using the CipherInputStream and CipherOutputStream.

The issue we were having last night was with CBC mode: each block to be decrypted required the decryption of the last block, and the stream objects really didn't like that. Trying to pipe that into the ObjectInputStream caused hanging (waiting for the full header), which gave us an exception and pipe collisions and all sorts of nastiness.  Switching to counter mode fixed the issue. 

Changes I made:
- `sendMessage()` and `getNextMessage()` in the chat sessions now throw generic exceptions (makes the code a lot cleaner, less try/catch blocks)
- Client and Server sessions now encrypt using the shared secret (*Note: I didn't implement the flag yet. This encrypts all the time.*)
- CryptoServices now uses counter mode instead of CBC (still works, checked unit tests).

I'll probably also write a quick test that checks that the CipherOutputStream is actually encrypting. Should be fairly simple.