### PR TITLE
Message Integrity Checking

### DIFF
--- a/src/main/java/canttouchthis/client/ClientSession.java
+++ b/src/main/java/canttouchthis/client/ClientSession.java
@@ -1,8 +1,8 @@
 package canttouchthis.client;
 
+import canttouchthis.common.ChatMessage;
 import canttouchthis.common.CryptoServices;
 import canttouchthis.common.IChatSession;
-import canttouchthis.common.Message;
 import canttouchthis.common.KeyEstablishment;
 
 import java.io.IOException;
@@ -27,8 +27,6 @@ import javax.crypto.Cipher;
 import java.security.spec.InvalidKeySpecException;
 
 //test stuff
-
-import java.util.Base64;
 
 
 /**
@@ -151,12 +149,12 @@ public class ClientSession implements IChatSession {
     }
 
     /**
-     * Sends a Message object to the server.
+     * Sends a ChatMessage object to the server.
      *
-     * @param m Message to be sent.
+     * @param m ChatMessage to be sent.
      * @throws IOException If an error is encountered sending over the websocket.
      */
-    public void sendMessage(Message m) throws Exception {
+    public void sendMessage(ChatMessage m) throws Exception {
 
         // initialize cipher
         Cipher c = (new CryptoServices()).getEncryptCipher(sharedSecret);
@@ -171,18 +169,18 @@ public class ClientSession implements IChatSession {
     /**
      * Blocks until a new message is received from the server.
      *
-     * @return New Message object from server.
+     * @return New ChatMessage object from server.
      * @throws IOException If an error is encountered reading from the websocket stream.
      */
-    public Message getNextMessage() throws Exception {
+    public ChatMessage getNextMessage() throws Exception {
 
         Cipher c = (new CryptoServices()).getDecryptCipher(sharedSecret);
         CipherInputStream cipherStream = new CipherInputStream(connection.getInputStream(), c);
         ObjectInputStream ois = new ObjectInputStream(cipherStream);
 
         try {
-            // TODO: what if we get sent an object that's not a Message?
-            return (Message) ois.readObject();
+            // TODO: what if we get sent an object that's not a ChatMessage?
+            return (ChatMessage) ois.readObject();
         }
         catch (ClassNotFoundException ex) {
             return null;

--- a/src/main/java/canttouchthis/client/ClientSession.java
+++ b/src/main/java/canttouchthis/client/ClientSession.java
@@ -172,13 +172,13 @@ public class ClientSession implements IChatSession {
      * @return New ChatMessage object from server.
      * @throws IOException If an error is encountered reading from the websocket stream.
      */
-    public ChatMessage getNextMessage() throws Exception {
+    public MessagePacket getNextMessage() throws Exception {
         Cipher c = (new CryptoServices()).getDecryptCipher(sharedSecret);
         CipherInputStream cipherStream = new CipherInputStream(connection.getInputStream(), c);
         ObjectInputStream ois = new ObjectInputStream(cipherStream);
 
         try {
-            return (ChatMessage) ((MessagePacket) ois.readObject()).getContent();
+            return (MessagePacket) ois.readObject();
         }
         catch (ClassCastException ex) {
             System.out.printf("Got unexpected class from socket!");

--- a/src/main/java/canttouchthis/common/ChatMessage.java
+++ b/src/main/java/canttouchthis/common/ChatMessage.java
@@ -9,14 +9,14 @@ import java.io.Serializable;
  * Container class for chat messages. This will likely change as more crypto
  * stuff gets added.
  */
-public class Message implements Serializable {
+public class ChatMessage implements Serializable {
 
     public final Date timestamp;
     public final String message;
 
     public Identity senderIdent;
 
-    public Message(String msg, long ts) {
+    public ChatMessage(String msg, long ts) {
         senderIdent = null;
         timestamp = new Date(ts);
         message = msg;

--- a/src/main/java/canttouchthis/common/IChatSession.java
+++ b/src/main/java/canttouchthis/common/IChatSession.java
@@ -7,17 +7,17 @@ public interface IChatSession {
     /**
      * Blocks until a new message is received from the server.
      *
-     * @return New Message object from server.
+     * @return New ChatMessage object from server.
      * @throws IOException If an error is encountered reading from the websocket stream.
      */
-    public Message getNextMessage() throws Exception;
+    public ChatMessage getNextMessage() throws Exception;
 
     /**
-     * Sends a Message object to the server.
+     * Sends a ChatMessage object to the server.
      *
-     * @param m Message to be sent.
+     * @param m ChatMessage to be sent.
      * @throws IOException If an error is encountered sending over the websocket.
      */
-    public void sendMessage(Message m) throws Exception;
+    public void sendMessage(ChatMessage m) throws Exception;
 
 }

--- a/src/main/java/canttouchthis/common/IChatSession.java
+++ b/src/main/java/canttouchthis/common/IChatSession.java
@@ -10,7 +10,7 @@ public interface IChatSession {
      * @return New ChatMessage object from server.
      * @throws IOException If an error is encountered reading from the websocket stream.
      */
-    public ChatMessage getNextMessage() throws Exception;
+    public MessagePacket getNextMessage() throws Exception;
 
     /**
      * Sends a ChatMessage object to the server.

--- a/src/main/java/canttouchthis/common/IntegrityChecking.java
+++ b/src/main/java/canttouchthis/common/IntegrityChecking.java
@@ -10,7 +10,7 @@ public class IntegrityChecking {
     /**
      * Generates a SHA-256 digest hash for a given message.
      *
-     * @param msg Message to create digest for.
+     * @param msg ChatMessage to create digest for.
      * @return Byte sequence representing the hash.
      */
     public static byte[] generateMessageDigest(String msg) {
@@ -33,7 +33,7 @@ public class IntegrityChecking {
      * If this function returns false, the message was likely modified in
      * transit.
      *
-     * @param msg Message text.
+     * @param msg ChatMessage text.
      * @param providedDigest SHA-256 digest provided along with the message.
      * @return Whether or not the hashed text and its provided digest match.
      */

--- a/src/main/java/canttouchthis/common/IntegrityChecking.java
+++ b/src/main/java/canttouchthis/common/IntegrityChecking.java
@@ -13,7 +13,7 @@ public class IntegrityChecking {
      * @param msg ChatMessage to create digest for.
      * @return Byte sequence representing the hash.
      */
-    public static byte[] generateMessageDigest(String msg) {
+    public static byte[] generateMessageDigest(byte[] msg) {
 
         MessageDigest algo;
         try {
@@ -24,7 +24,7 @@ public class IntegrityChecking {
             return null;
         }
 
-        return algo.digest(msg.getBytes());
+        return algo.digest(msg);
 
     }
 
@@ -37,7 +37,7 @@ public class IntegrityChecking {
      * @param providedDigest SHA-256 digest provided along with the message.
      * @return Whether or not the hashed text and its provided digest match.
      */
-    public static boolean checkDigest(String msg, byte[] providedDigest) {
+    public static boolean checkDigest(byte[] msg, byte[] providedDigest) {
 
         // Generate a digest for the String message. This should be the same
         // as the provided digest if the message has not been modified.

--- a/src/main/java/canttouchthis/common/MessageMonitorThread.java
+++ b/src/main/java/canttouchthis/common/MessageMonitorThread.java
@@ -49,11 +49,17 @@ public class MessageMonitorThread extends Thread {
         this._alive = true;
         while (this._alive) {
             try {
-                ChatMessage m = this._session.getNextMessage();
+                MessagePacket packet = this._session.getNextMessage();
+                ChatMessage m = (ChatMessage) packet.getContent();
 
                 // check message identity against database
                 if (!(this._auth.verifyIdentity(m.senderIdent))){
                     this._ui.showWarning("Sender could not be verified!");
+                }
+
+                // check message digests
+                if (!(packet.checkMessageDigest())) {
+                    this._ui.showWarning("Digests do not match - message may have been intercepted!");
                 }
 
                 this._ui.addMessage(m);

--- a/src/main/java/canttouchthis/common/MessageMonitorThread.java
+++ b/src/main/java/canttouchthis/common/MessageMonitorThread.java
@@ -33,7 +33,7 @@ public class MessageMonitorThread extends Thread {
         ConversationController ui = this._ui;
         this._ui.setSendHandler(new ISendHandler() {
             @Override
-            public void onMessageSend(Message m) {
+            public void onMessageSend(ChatMessage m) {
                 try {
                     m.setIdentity(ident);
                     ui.addMessage(m);
@@ -49,7 +49,7 @@ public class MessageMonitorThread extends Thread {
         this._alive = true;
         while (this._alive) {
             try {
-                Message m = this._session.getNextMessage();
+                ChatMessage m = this._session.getNextMessage();
 
                 // check message identity against database
                 if (!(this._auth.verifyIdentity(m.senderIdent))){

--- a/src/main/java/canttouchthis/common/MessagePacket.java
+++ b/src/main/java/canttouchthis/common/MessagePacket.java
@@ -1,0 +1,39 @@
+package canttouchthis.common;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+/**
+ * Contains a serializable object and a SHA-256 digest, which can be checked
+ * after the packet has been transmitted. If the packet content and its digest
+ * do not match, the packet may have been intercepted!
+ */
+public class MessagePacket implements Serializable {
+
+    private Serializable _content;
+    private byte[] _digest;
+
+    public MessagePacket(Serializable s) throws IOException {
+
+        this._content = s;
+
+        // create digest for message content
+        this._digest = genDigest(s);
+
+    }
+
+    public boolean checkMessageDigest() throws IOException {
+        return IntegrityChecking.checkDigest(this._digest, genDigest(this._content));
+    }
+
+    private byte[] genDigest(Serializable s) throws IOException {
+        ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(byteOutStream);
+        oos.writeObject(s);
+
+        return IntegrityChecking.generateMessageDigest(byteOutStream.toByteArray());
+    }
+
+}

--- a/src/main/java/canttouchthis/common/MessagePacket.java
+++ b/src/main/java/canttouchthis/common/MessagePacket.java
@@ -24,6 +24,10 @@ public class MessagePacket implements Serializable {
 
     }
 
+    public Serializable getContent() {
+        return this._content;
+    }
+
     public boolean checkMessageDigest() throws IOException {
         return IntegrityChecking.checkDigest(this._digest, genDigest(this._content));
     }

--- a/src/main/java/canttouchthis/common/MessagePacket.java
+++ b/src/main/java/canttouchthis/common/MessagePacket.java
@@ -20,7 +20,7 @@ public class MessagePacket implements Serializable {
         this._content = s;
 
         // create digest for message content
-        this._digest = genDigest(s);
+        this._digest = genDigest(this._content);
 
     }
 
@@ -29,7 +29,11 @@ public class MessagePacket implements Serializable {
     }
 
     public boolean checkMessageDigest() throws IOException {
-        return IntegrityChecking.checkDigest(this._digest, genDigest(this._content));
+        ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(byteOutStream);
+        oos.writeObject(this._content);
+
+        return IntegrityChecking.checkDigest(byteOutStream.toByteArray(), this._digest);
     }
 
     private byte[] genDigest(Serializable s) throws IOException {

--- a/src/main/java/canttouchthis/common/auth/Authenticator.java
+++ b/src/main/java/canttouchthis/common/auth/Authenticator.java
@@ -49,7 +49,8 @@ public class Authenticator {
         if (s.next()) {
 
             // SHA-256 hash of password should match value in database.
-            String reqHash = Base64.getEncoder().encodeToString(IntegrityChecking.generateMessageDigest(password));
+            String reqHash = Base64.getEncoder()
+                    .encodeToString(IntegrityChecking.generateMessageDigest(password.getBytes()));
             String dbHash = s.getString(1);
 
             if (reqHash.equals(dbHash)) {

--- a/src/main/java/canttouchthis/server/ServerSession.java
+++ b/src/main/java/canttouchthis/server/ServerSession.java
@@ -1,7 +1,7 @@
 package canttouchthis.server;
 
+import canttouchthis.common.ChatMessage;
 import canttouchthis.common.CryptoServices;
-import canttouchthis.common.Message;
 import canttouchthis.common.IChatSession;
 import canttouchthis.common.KeyEstablishment;
 
@@ -30,12 +30,10 @@ import javax.crypto.Cipher;
 import java.security.spec.InvalidKeySpecException;
 
 //test
-import java.util.Base64;
-
 
 
 /**
- * Handles sending and recieving Message objects and key exchange on the
+ * Handles sending and recieving ChatMessage objects and key exchange on the
  * server side.
  */
 public class ServerSession implements IChatSession {
@@ -192,10 +190,10 @@ public class ServerSession implements IChatSession {
     /**
      * Sends a message object to the connected ClientSession.
      *
-     * @param m Message object to be sent.
+     * @param m ChatMessage object to be sent.
      * @throws IOException If an error occurs when writing the message to the websocket channel.
      */
-    public void sendMessage(Message m) throws Exception {
+    public void sendMessage(ChatMessage m) throws Exception {
 
         // initialize encryption cipher
         Cipher c = (new CryptoServices()).getEncryptCipher(sharedSecret);
@@ -208,20 +206,20 @@ public class ServerSession implements IChatSession {
     }
 
     /**
-     * Blocks until a new Message object is received from the client.
+     * Blocks until a new ChatMessage object is received from the client.
      *
-     * @return Message from the ClientSession.
+     * @return ChatMessage from the ClientSession.
      * @throws IOException If any errors occur when getting the socket input stream.
      */
-    public Message getNextMessage() throws Exception {
+    public ChatMessage getNextMessage() throws Exception {
         Cipher c = (new CryptoServices()).getDecryptCipher(sharedSecret);
         CipherInputStream cipherStream = new CipherInputStream(channel.getInputStream(), c);
 
         ObjectInputStream ois = new ObjectInputStream(cipherStream);
 
         try {
-            // TODO: what if we get sent an object that's not a Message?
-            return (Message) ois.readObject();
+            // TODO: what if we get sent an object that's not a ChatMessage?
+            return (ChatMessage) ois.readObject();
         }
         catch (ClassNotFoundException ex) {
             return null;

--- a/src/main/java/canttouchthis/server/ServerSession.java
+++ b/src/main/java/canttouchthis/server/ServerSession.java
@@ -211,14 +211,14 @@ public class ServerSession implements IChatSession {
      * @return ChatMessage from the ClientSession.
      * @throws IOException If any errors occur when getting the socket input stream.
      */
-    public ChatMessage getNextMessage() throws Exception {
+    public MessagePacket getNextMessage() throws Exception {
         Cipher c = (new CryptoServices()).getDecryptCipher(sharedSecret);
         CipherInputStream cipherStream = new CipherInputStream(channel.getInputStream(), c);
 
         ObjectInputStream ois = new ObjectInputStream(cipherStream);
 
         try {
-            return (ChatMessage) ((MessagePacket) ois.readObject()).getContent();
+            return (MessagePacket) ois.readObject();
         }
         catch (ClassCastException ex) {
             System.out.printf("Got unexpected class from socket!");

--- a/src/main/java/canttouchthis/ui/ConversationController.java
+++ b/src/main/java/canttouchthis/ui/ConversationController.java
@@ -1,6 +1,6 @@
 package canttouchthis.ui;
 
-import canttouchthis.common.Message;
+import canttouchthis.common.ChatMessage;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
@@ -43,7 +43,7 @@ public class ConversationController implements ActionListener, KeyListener {
     /**
      * Sets a handler for a message send event from the UI.
      *
-     * @param sendHandler ISendHandler object which processes a Message object.
+     * @param sendHandler ISendHandler object which processes a ChatMessage object.
      */
     public void setSendHandler(ISendHandler sendHandler) {
         this.sendHandler = sendHandler;
@@ -54,14 +54,14 @@ public class ConversationController implements ActionListener, KeyListener {
      *
      * @param m New message to be added.
      */
-    public void addMessage(Message m) {
+    public void addMessage(ChatMessage m) {
         this._model.addMessage(m);
         this._view.renderMessage(m);
     }
 
     /**
      * Shows a warning in the chat view.
-     * @param message Message to be shown to the user.
+     * @param message ChatMessage to be shown to the user.
      */
     public void showWarning(String message) {
         this._view.renderWarningMessage(message);
@@ -129,7 +129,7 @@ public class ConversationController implements ActionListener, KeyListener {
     public void keyReleased(KeyEvent e) { }
 
     private void onSend() {
-        Message m = new Message(_view.sendField.getText(), System.currentTimeMillis());
+        ChatMessage m = new ChatMessage(_view.sendField.getText(), System.currentTimeMillis());
 
         // clear message field
         this._view.sendField.setText("");

--- a/src/main/java/canttouchthis/ui/ConversationModel.java
+++ b/src/main/java/canttouchthis/ui/ConversationModel.java
@@ -1,6 +1,7 @@
 package canttouchthis.ui;
 
-import canttouchthis.common.Message;
+import canttouchthis.common.ChatMessage;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 
@@ -11,21 +12,21 @@ public class ConversationModel {
 
     private final int INITIAL_CAPACITY = 200;
 
-    private ArrayList<Message> messages;
+    private ArrayList<ChatMessage> messages;
 
     public ConversationModel() {
         messages = new ArrayList<>(INITIAL_CAPACITY);
     }
 
-    public void addMessage(Message m) {
+    public void addMessage(ChatMessage m) {
         messages.add(m);
     }
 
-    public Iterator<Message> messages() {
+    public Iterator<ChatMessage> messages() {
         return messages.iterator();
     }
 
-    public Message getLastMessage() {
+    public ChatMessage getLastMessage() {
         return messages.get(messages.size() - 1);
     }
 

--- a/src/main/java/canttouchthis/ui/ConversationView.java
+++ b/src/main/java/canttouchthis/ui/ConversationView.java
@@ -1,12 +1,10 @@
 package canttouchthis.ui;
 
-import canttouchthis.common.Message;
+import canttouchthis.common.ChatMessage;
 import java.awt.*;
 import java.text.SimpleDateFormat;
 import java.util.Iterator;
 import javax.swing.*;
-import javax.swing.text.SimpleAttributeSet;
-import javax.swing.text.StyleConstants;
 
 /**
  * Window for sending and recieving chat messages (client or server side).
@@ -99,7 +97,7 @@ public class ConversationView extends JFrame {
     public void updateConversation() {
         // re-render all messages
         chatPane.setText("");
-        Iterator<Message> i = model.messages();
+        Iterator<ChatMessage> i = model.messages();
         while (i.hasNext()) {
             renderMessage(i.next());
         }
@@ -107,7 +105,7 @@ public class ConversationView extends JFrame {
 
     /**
      * Render a warning to the chat view.
-     * @param message Message to be displayed after "WARNING: "
+     * @param message ChatMessage to be displayed after "WARNING: "
      */
     protected void renderWarningMessage(String message) {
         String rendered = "WARNING: " + message + "\n";
@@ -115,10 +113,10 @@ public class ConversationView extends JFrame {
     }
 
     /**
-     * Render a Message object to the view.
-     * @param m Message to be rendered.
+     * Render a ChatMessage object to the view.
+     * @param m ChatMessage to be rendered.
      */
-    protected void renderMessage(Message m) {
+    protected void renderMessage(ChatMessage m) {
         String rendered = String.format("[%s] %s: %s\n", date_format.format(m.timestamp),
                 m.getSenderName(), m.message);
 

--- a/src/main/java/canttouchthis/ui/ISendHandler.java
+++ b/src/main/java/canttouchthis/ui/ISendHandler.java
@@ -1,6 +1,6 @@
 package canttouchthis.ui;
 
-import canttouchthis.common.Message;
+import canttouchthis.common.ChatMessage;
 
 /**
  * Implement this to handle a new message being sent from a ConversationView.
@@ -9,8 +9,8 @@ public interface ISendHandler {
 
     /**
      * Called when the "send" button is pressed in the UI.
-     * @param m Message object from the UI.
+     * @param m ChatMessage object from the UI.
      */
-    void onMessageSend(Message m);
+    void onMessageSend(ChatMessage m);
 
 }

--- a/src/main/java/canttouchthis/ui/WaitForConnectionDialog.java
+++ b/src/main/java/canttouchthis/ui/WaitForConnectionDialog.java
@@ -17,7 +17,7 @@ public class WaitForConnectionDialog extends JFrame {
     /**
      * Create a dialog showing that a server is waiting for a connection.
      *
-     * Message:
+     * ChatMessage:
      *   Waiting for connections...
      *   Host: ${HOSTNAME}:${PORT}
      *

--- a/src/test/java/ctttest/common/TestCryptoServices.java
+++ b/src/test/java/ctttest/common/TestCryptoServices.java
@@ -1,6 +1,6 @@
 package ctttest.common;
 
-import canttouchthis.common.Message;
+import canttouchthis.common.ChatMessage;
 import canttouchthis.common.CryptoServices;
 
 import java.io.ObjectOutputStream;
@@ -49,7 +49,7 @@ public class TestCryptoServices extends TestCase {
         Key key = keyGen.generateKey();
 
         // Create generic message
-        Message m = new Message("I am a walrus.", 12);
+        ChatMessage m = new ChatMessage("I am a walrus.", 12);
 
         // Create two pipelines: one uses the encryption cipher, one doesn't
         ByteArrayOutputStream byteStreamNoEncrypt = new ByteArrayOutputStream();

--- a/src/test/java/ctttest/common/TestIntegrityChecking.java
+++ b/src/test/java/ctttest/common/TestIntegrityChecking.java
@@ -14,7 +14,7 @@ public class TestIntegrityChecking extends TestCase {
      */
     public void testLengthOfHash() {
 
-        byte[] hash = IntegrityChecking.generateMessageDigest(message);
+        byte[] hash = IntegrityChecking.generateMessageDigest(message.getBytes());
 
         assertEquals(32, hash.length);
 
@@ -25,8 +25,8 @@ public class TestIntegrityChecking extends TestCase {
      */
     public void testHashOfSameMessageIsSame() {
 
-        byte[] hash = IntegrityChecking.generateMessageDigest(message);
-        byte[] hash2 = IntegrityChecking.generateMessageDigest(message);
+        byte[] hash = IntegrityChecking.generateMessageDigest(message.getBytes());
+        byte[] hash2 = IntegrityChecking.generateMessageDigest(message.getBytes());
 
         assertTrue(MessageDigest.isEqual(hash, hash2));
 
@@ -34,8 +34,8 @@ public class TestIntegrityChecking extends TestCase {
 
     public void testHashOfDifferentMessageIsDifferent() {
 
-        byte[] hash = IntegrityChecking.generateMessageDigest(message);
-        byte[] hash2 = IntegrityChecking.generateMessageDigest(message + "; badstuff");
+        byte[] hash = IntegrityChecking.generateMessageDigest(message.getBytes());
+        byte[] hash2 = IntegrityChecking.generateMessageDigest((message + "; badstuff").getBytes());
 
         assertTrue(!MessageDigest.isEqual(hash, hash2));
 

--- a/src/test/java/ctttest/net/NetUtilityThreads.java
+++ b/src/test/java/ctttest/net/NetUtilityThreads.java
@@ -1,7 +1,7 @@
 package ctttest.net;
 
 import canttouchthis.client.ClientSession;
-import canttouchthis.common.Message;
+import canttouchthis.common.ChatMessage;
 import canttouchthis.server.ServerSession;
 
 import java.io.ObjectInputStream;
@@ -23,7 +23,7 @@ public class NetUtilityThreads {
      */
     protected static class TryRecieveMessageClient extends Thread {
         ClientSession c;
-        Message message = null;
+        ChatMessage message = null;
         boolean success = false;
 
         public TryRecieveMessageClient(ClientSession c) {
@@ -46,11 +46,11 @@ public class NetUtilityThreads {
 
     /**
      * Starts a ServerSession and waits for a client to connect. Then, waits for the
-     * ClientSession to send a Message.
+     * ClientSession to send a ChatMessage.
      */
     protected static class TryRecieveMessageServer extends Thread {
         ServerSession s;
-        Message message = null;
+        ChatMessage message = null;
         boolean success = false;
 
         public TryRecieveMessageServer(ServerSession s) {
@@ -72,11 +72,11 @@ public class NetUtilityThreads {
 
     /**
      * Generic websocket server (not ServerSession). Starts the server, waits for a connection
-     * and (optionally) waits to receive a Message.
+     * and (optionally) waits to receive a ChatMessage.
      */
     protected static class WaitForConnection extends Thread {
         int port;
-        Message message;
+        ChatMessage message;
         boolean success = false;
         boolean tryReadMessage;
 
@@ -92,7 +92,7 @@ public class NetUtilityThreads {
 
                 if (tryReadMessage) {
                     ObjectInputStream ois = new ObjectInputStream(sock.getInputStream());
-                    message = (Message) ois.readObject();
+                    message = (ChatMessage) ois.readObject();
                 }
 
                 s.close();
@@ -115,7 +115,7 @@ public class NetUtilityThreads {
         InetAddress addr;
         int port;
         boolean tryReadMessage;
-        Message message = null;
+        ChatMessage message = null;
 
         boolean success;
 
@@ -134,7 +134,7 @@ public class NetUtilityThreads {
                 // try to get a message from the server
                 if (tryReadMessage) {
                     ObjectInputStream ois = new ObjectInputStream(s.getInputStream());
-                    message = (Message) ois.readObject();
+                    message = (ChatMessage) ois.readObject();
                 }
 
                 s.close();

--- a/src/test/java/ctttest/net/NetUtilityThreads.java
+++ b/src/test/java/ctttest/net/NetUtilityThreads.java
@@ -2,6 +2,7 @@ package ctttest.net;
 
 import canttouchthis.client.ClientSession;
 import canttouchthis.common.ChatMessage;
+import canttouchthis.common.MessagePacket;
 import canttouchthis.server.ServerSession;
 
 import java.io.ObjectInputStream;
@@ -34,7 +35,7 @@ public class NetUtilityThreads {
             try {
                 Thread.sleep(3000);
                 c.connect(SERVER_ADDR, SERVER_PORT);
-                message = c.getNextMessage();
+                message = (ChatMessage) c.getNextMessage().getContent();
                 success = true;
             }
             catch (Exception ex) {
@@ -60,7 +61,7 @@ public class NetUtilityThreads {
         public void run() {
             s.waitForConnection();
             try {
-                message = s.getNextMessage();
+                message = (ChatMessage) s.getNextMessage().getContent();
                 success = true;
             }
             catch (Exception ex) {

--- a/src/test/java/ctttest/net/TestClientServerConnection.java
+++ b/src/test/java/ctttest/net/TestClientServerConnection.java
@@ -1,12 +1,11 @@
 package ctttest.net;
 
+import canttouchthis.common.ChatMessage;
 import ctttest.net.NetUtilityThreads.*;
 
-import canttouchthis.common.Message;
 import canttouchthis.client.ClientSession;
 import canttouchthis.server.ServerSession;
 
-import java.io.IOException;
 import java.net.UnknownHostException;
 
 import junit.framework.*;
@@ -25,7 +24,7 @@ public class TestClientServerConnection extends TestCase {
         // SETUP
         ServerSession s = new ServerSession();
         ClientSession c = new ClientSession();
-        Message m = new Message("This is a test!!!", 0);
+        ChatMessage m = new ChatMessage("This is a test!!!", 0);
 
         // EXEC
         TryRecieveMessageClient cThread = new TryRecieveMessageClient(c);
@@ -40,7 +39,7 @@ public class TestClientServerConnection extends TestCase {
             assertTrue("Exception when sending message!", false);
         }
 
-        Message recv = cThread.message;
+        ChatMessage recv = cThread.message;
 
         // VERIFY
         assertTrue("Error running client thread!", cThread.success);
@@ -49,7 +48,7 @@ public class TestClientServerConnection extends TestCase {
     }
 
     /**
-     * Checks that a ServerSession can send a Message to a ClientSession.
+     * Checks that a ServerSession can send a ChatMessage to a ClientSession.
      *
      * @throws UnknownHostException If localhost cannot be found.
      */
@@ -57,7 +56,7 @@ public class TestClientServerConnection extends TestCase {
         // SETUP
         ServerSession s = new ServerSession();
         ClientSession c = new ClientSession();
-        Message m = new Message("This is a test!!!", 0);
+        ChatMessage m = new ChatMessage("This is a test!!!", 0);
 
         // EXEC
         TryRecieveMessageServer sThread = new TryRecieveMessageServer(s);
@@ -72,7 +71,7 @@ public class TestClientServerConnection extends TestCase {
             assertTrue("Exception when sending message!", false);
         }
 
-        Message recv = sThread.message;
+        ChatMessage recv = sThread.message;
 
         // VERIFY
         assertTrue("Error running client thread!", sThread.success);

--- a/src/test/java/ctttest/net/TestClientSession.java
+++ b/src/test/java/ctttest/net/TestClientSession.java
@@ -63,7 +63,7 @@ public class TestClientSession extends TestCase {
 /*
     public void testMessageSerialization() {
         // SETUP
-        Message m = new Message("This is a test!!!", 0);
+        ChatMessage m = new ChatMessage("This is a test!!!", 0);
         WaitForConnection server = new WaitForConnection(50000, true);
         server.start();
 
@@ -79,7 +79,7 @@ public class TestClientSession extends TestCase {
             success = false;
         }
 
-        Message recv = server.message;
+        ChatMessage recv = server.message;
 
         // VERIFY
         assertTrue(success);

--- a/src/test/java/ctttest/net/TestServerSession.java
+++ b/src/test/java/ctttest/net/TestServerSession.java
@@ -57,7 +57,7 @@ public class TestServerSession extends TestCase {
      */
 /*    public void testMessageSerialization() throws UnknownHostException {
         // SETUP
-        Message m = new Message("This is a test!!!", 0);
+        ChatMessage m = new ChatMessage("This is a test!!!", 0);
         TryConnect conThread = new TryConnect(InetAddress.getLocalHost(), ServerSession.DEFAULT_PORT, true);
 
         // EXEC
@@ -78,7 +78,7 @@ public class TestServerSession extends TestCase {
             assertTrue("Connection thread interrupted!", false);
         }
 
-        Message recv = conThread.message;
+        ChatMessage recv = conThread.message;
 
         // VERIFY
         assertTrue(success);


### PR DESCRIPTION
Client and server should now check message hashes.

Changes:
- Chat messages are now transmitted in message packets (just contains message + hash)
- MessageMonitorThread will warn the user if the message hash does not match the hash of the message content. 